### PR TITLE
Correct initializers guide for v2.0.

### DIFF
--- a/source/applications/initializers.md
+++ b/source/applications/initializers.md
@@ -33,7 +33,7 @@ Let's customize the `shopping-cart` initializer to inject a `cart` property into
 all the routes in your application:
 
 ```app/initializers/shopping-cart.js
-export function initialize(application) {
+export function initialize(container, application) {
   application.inject('route', 'cart', 'service:shopping-cart');
 };
 
@@ -56,7 +56,7 @@ Let's add some simple logging to indicate that the instance has booted:
 
 ```app/instance-initializers/logger.js
 export function initialize(applicationInstance) {
-  var logger = applicationInstance.lookup('logger:main');
+  var logger = applicationInstance.container.lookup('logger:main');
   logger.log('Hello from the instance initializer!');
 }
 
@@ -72,7 +72,7 @@ If you'd like to control the order in which initializers run, you can use the
 `before` and/or `after` options:
 
 ```app/initializers/config-reader.js
-export function initialize(application) {
+export function initialize(container, application) {
   // ... your code ...
 };
 
@@ -84,7 +84,7 @@ export default {
 ```
 
 ```app/initializers/websocket-init.js
-export function initialize(application) {
+export function initialize(container, application) {
   // ... your code ...
 };
 


### PR DESCRIPTION
In ember 2.0 initializers expect two arguments `container` and `application`.  Also the `applicationInstance` argument of the instance initializers do not have a method `lookup` one must call `lookup` on the `container` attribute of the `applicationInstance`.